### PR TITLE
Add endpoint to show all upcoming events

### DIFF
--- a/cmoa-calendar.php
+++ b/cmoa-calendar.php
@@ -179,7 +179,8 @@ class CMOA_Calendar {
     $events = $search->get_events_between(
 			$start_time,
 			$end_time,
-      $filters // array of category/tag ids
+      $filters, // array of category/tag ids
+      true
 		);
 
     $visible_events = array_filter($events, function($event) {
@@ -202,7 +203,7 @@ class CMOA_Calendar {
 	*  @return events array with desired structure
 	*/
 
-  private function format_events($events) {
+  function format_events($events) {
     $event_list = [];
     $tz = new DateTimeZone($this->_timezone);
 
@@ -548,6 +549,38 @@ add_action('rest_api_init', function () {
   ));
 });
 
+/*
+*  calendar_upcoming_api
+*
+*  This function is called from the API route and passes the current date to
+*  show all upcoming events.
+*
+*  @type  function
+*  @date  02/2/17
+*  @since 1.2.5
+*
+*  @return JSON object representing event
+*/
+
+function calendar_upcoming_api() {
+  $cal = new CMOA_Calendar();
+  $events = $cal->all_upcoming_events();
+
+  // Filter down to unique events
+  $unique_events = $cal->unique_events($events);
+
+  // Format events
+  $formatted_events = $cal->format_events($unique_events);
+
+  return $formatted_events;
+}
+
+add_action('rest_api_init', function () {
+  register_rest_route('events/v1', '/upcoming/', array(
+    'methods' => 'GET',
+    'callback' => 'calendar_upcoming_api'
+  ));
+});
 
 /*
 *  calendar_categories_api

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "carneyplusco/cmoa-calendar",
   "description": "Bridge to All-in-one Event Calendar data",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "keywords": ["wordpress", "plugin", "carneyplusco", "all-in-one-event-calendar"],
   "homepage": "https://carney.co",
   "license": "MIT",


### PR DESCRIPTION
This will be used by the Warhol.org site, which is also using the CMOA calendar plugin. Adds an endpoint, `/wp-json/events/v1/upcoming`, that shows all upcoming events