### PR TITLE
Add filter to format_events() to allow other sites to modify the response

### DIFF
--- a/cmoa-calendar.php
+++ b/cmoa-calendar.php
@@ -260,6 +260,15 @@ class CMOA_Calendar {
 
     usort($event_list, array('self', 'sort_events_by_hour'));
 
+    /**
+     * Filters the list of events, for other sites to add additional fields.
+     *
+     * @since 1.2.4
+     *
+     * @param $event_list Formatted array of event data.
+     */
+    apply_filters( 'carnegie_format_events_for_rest_api', $event_list );
+
     return $event_list;
   }
 

--- a/cmoa-calendar.php
+++ b/cmoa-calendar.php
@@ -267,7 +267,7 @@ class CMOA_Calendar {
      *
      * @param $event_list Formatted array of event data.
      */
-    apply_filters( 'carnegie_format_events_for_rest_api', $event_list );
+    $event_list = apply_filters( 'carnegie_format_events_for_rest_api', $event_list );
 
     return $event_list;
   }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "carneyplusco/cmoa-calendar",
   "description": "Bridge to All-in-one Event Calendar data",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "keywords": ["wordpress", "plugin", "carneyplusco", "all-in-one-event-calendar"],
   "homepage": "https://carney.co",
   "license": "MIT",


### PR DESCRIPTION
This allows other plugins/themes to filter the results sent to the API endpoints.

On Warhol.org, we're using this API plus a few additional fields that need to be included in the response. 